### PR TITLE
Adjusted config for testing/linting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,3 +34,5 @@ jobs:
         with:
           commit_message: Apply prettier formatting changes
           branch: ${{ github.head_ref }}
+      - name: Jest Tests
+        run: npm run test

--- a/editorextensions/UVexplorer-integration/.eslintrc.js
+++ b/editorextensions/UVexplorer-integration/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
         project: true,
         tsconfigRootDir: __dirname
     },
-    root: true,
+    root: ['./tsconfig.json', './test/tsconfig.json'],
     overrides: [
         {
             files: ['*.js'],

--- a/editorextensions/UVexplorer-integration/.eslintrc.js
+++ b/editorextensions/UVexplorer-integration/.eslintrc.js
@@ -10,10 +10,10 @@ module.exports = {
     plugins: ['@typescript-eslint'],
     parser: '@typescript-eslint/parser',
     parserOptions: {
-        project: true,
+        project: ['tsconfig.json', 'test/tsconfig.json'],
         tsconfigRootDir: __dirname
     },
-    root: ['./tsconfig.json', './test/tsconfig.json'],
+    root: true,
     overrides: [
         {
             files: ['*.js'],

--- a/editorextensions/UVexplorer-integration/.eslintrc.js
+++ b/editorextensions/UVexplorer-integration/.eslintrc.js
@@ -10,7 +10,12 @@ module.exports = {
     plugins: ['@typescript-eslint'],
     parser: '@typescript-eslint/parser',
     parserOptions: {
-        project: ['tsconfig.json', 'test/tsconfig.json'],
+        project: [
+            './tsconfig.json',
+            './test/tsconfig.json',
+            './control-panel/tsconfig.json',
+            './control-panel/tsconfig.spec.json'
+        ],
         tsconfigRootDir: __dirname
     },
     root: true,

--- a/editorextensions/UVexplorer-integration/jest.config.js
+++ b/editorextensions/UVexplorer-integration/jest.config.js
@@ -2,5 +2,13 @@
 module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
-    testPathIgnorePatterns: ['/control-panel/']
+    testPathIgnorePatterns: ['/control-panel/'],
+    transform: {
+        '^.+\\.ts$': [
+            'ts-jest',
+            {
+                tsconfig: 'test/tsconfig.json'
+            }
+        ]
+    }
 };

--- a/editorextensions/UVexplorer-integration/src/actions/devices.ts
+++ b/editorextensions/UVexplorer-integration/src/actions/devices.ts
@@ -1,0 +1,16 @@
+import { BlockProxy, Viewport } from 'lucid-extension-sdk';
+
+export function uvDeviceSelected(viewport: Viewport): boolean {
+    console.log('In uvDeviceSelected');
+    const selection = viewport.getSelectedItems();
+    // TODO: check if instance of uvDevice class
+    const isCorrectSelection = selection.length > 0 && selection.every((item) => item instanceof BlockProxy);
+    console.log('Should show menu item', isCorrectSelection);
+    return isCorrectSelection;
+}
+
+export function showConnectedDevices(viewport: Viewport): void {
+    const selection = viewport.getSelectedItems();
+    // TODO: add the connected devices for each of the selected items
+    console.log('Selection:', selection);
+}

--- a/editorextensions/UVexplorer-integration/src/extension.ts
+++ b/editorextensions/UVexplorer-integration/src/extension.ts
@@ -1,5 +1,6 @@
 import { EditorClient, Menu, Modal, Viewport } from 'lucid-extension-sdk';
 import { UVexplorerModal } from './uvexplorer-modal';
+import { showConnectedDevices, uvDeviceSelected } from './actions/devices';
 
 class FirstModal extends Modal {
     constructor(client: EditorClient) {
@@ -26,6 +27,19 @@ class SecondModal extends Modal {
 const client = new EditorClient();
 const menu = new Menu(client);
 const viewport: Viewport = new Viewport(client);
+
+client.registerAction('uvDeviceSelected', () => {
+    console.log('First in uvDeviceSelected');
+    return uvDeviceSelected(viewport);
+});
+
+client.registerAction('showConnectedDevices', () => showConnectedDevices(viewport));
+
+menu.addContextMenuItem({
+    label: 'Show connected devices',
+    action: 'showConnectedDevices',
+    visibleAction: 'uvDeviceSelected'
+});
 
 client.registerAction('loadNetwork', async () => {
     const modal = new UVexplorerModal(client, viewport);

--- a/editorextensions/UVexplorer-integration/test/__tests__/actions/devices.test.ts
+++ b/editorextensions/UVexplorer-integration/test/__tests__/actions/devices.test.ts
@@ -1,0 +1,37 @@
+import { uvDeviceSelected, showConnectedDevices } from '../../../src/actions/devices';
+import * as lucid from 'lucid-extension-sdk';
+
+jest.mock('lucid-extension-sdk');
+
+beforeEach(() => {
+    jest.resetModules();
+});
+
+describe('Device actions success tests', () => {
+    const mockSelection = [
+        new lucid.BlockProxy('1', {} as lucid.EditorClient),
+        new lucid.BlockProxy('1', {} as lucid.EditorClient)
+    ] as lucid.ItemProxy[];
+    const mockViewport = {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        getSelectedItems: (_deep?: boolean | undefined) => mockSelection
+    } as lucid.Viewport;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    describe('uvDeviceSelected tests', () => {
+        it('should be true when multiple uvDevices are selected', () => {
+            expect(uvDeviceSelected(mockViewport)).toBeTruthy();
+        });
+    });
+
+    describe('showConnectedDevices tests', () => {
+        it('should call console.log with selected items', () => {
+            const logSpy = jest.spyOn(console, 'log');
+            showConnectedDevices(mockViewport);
+            expect(logSpy).toHaveBeenCalledWith('Selection:', mockSelection);
+        });
+    });
+});

--- a/editorextensions/UVexplorer-integration/test/tsconfig.json
+++ b/editorextensions/UVexplorer-integration/test/tsconfig.json
@@ -1,4 +1,5 @@
 {
+    "extends": "../tsconfig.json",
     "compilerOptions": {
         "declaration": true,
         "emitDecoratorMetadata": true,
@@ -21,7 +22,7 @@
         "strictNullChecks": true,
         "strictPropertyInitialization": true,
         "target": "ESNext",
-        "types": ["node"],
+        "types": ["node", "jest"],
         "lib": [
             "es5",
             "es6",
@@ -33,6 +34,5 @@
         ],
         "outDir": "bin"
     },
-    "files": ["resources/resource.d.ts"],
-    "include": ["src/**/*", "model/*"]
+    "include": ["__tests__/**/*.ts", "__mocks__/**/*.ts"]
 }


### PR DESCRIPTION
Removed test files from root tsconfig so they won't be transpiled with the actual extension code (no reason for them to be). Created new tsconfig specifically for tests so eslint can find them and so jest global types are still available within test directory.