### PR TITLE
getNetworkForPage() and misc. fixes

### DIFF
--- a/editorextensions/UVexplorer-integration/control-panel/src/app/networks/networks.component.ts
+++ b/editorextensions/UVexplorer-integration/control-panel/src/app/networks/networks.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NetworkSummary } from 'model/uvexplorer-model';
-import { isListNetworksMessage } from 'model/message';
+import { isListNetworksMessage, listNetworksMessageToNetworkSummaries } from 'model/message';
 import { NgForOf, NgIf } from '@angular/common';
 import { DevicesComponent } from '../devices/devices.component';
 
@@ -28,9 +28,12 @@ export class NetworksComponent {
     window.addEventListener('message', (e) => {
       console.log('Received a message from the parent.');
       console.log(e.data);
-      if (isListNetworksMessage(e.data)) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        this.network_summaries = JSON.parse(e.data.network_summaries);
+      try {
+        if (isListNetworksMessage(e.data)) {
+          this.network_summaries = listNetworksMessageToNetworkSummaries(e.data);
+        }
+      } catch (e) {
+        console.error(e);
       }
     });
   }

--- a/editorextensions/UVexplorer-integration/model/message.ts
+++ b/editorextensions/UVexplorer-integration/model/message.ts
@@ -1,4 +1,4 @@
-import { Device } from './uvexplorer-model';
+import { Device, isNetworkSummary, NetworkSummary } from './uvexplorer-model';
 
 export interface ListNetworksMessage {
     action: 'listNetworks';
@@ -15,6 +15,14 @@ export function isListNetworksMessage(message: unknown): message is ListNetworks
         'network_summaries' in message &&
         typeof message.network_summaries === 'string'
     );
+}
+
+export function listNetworksMessageToNetworkSummaries(message: ListNetworksMessage): NetworkSummary[] {
+    const networkSummaries: unknown = JSON.parse(message.network_summaries);
+    if (Array.isArray(networkSummaries) && networkSummaries.every(isNetworkSummary)) {
+        return networkSummaries;
+    }
+    throw new Error('Could not parse network summaries from message.');
 }
 
 export interface LoadNetworkMessage {

--- a/editorextensions/UVexplorer-integration/model/uvexplorer-model.ts
+++ b/editorextensions/UVexplorer-integration/model/uvexplorer-model.ts
@@ -175,7 +175,7 @@ export interface NetworkSummary {
     modified_time: string;
     name: string;
     description: string;
-    agent_summaries: AgentSummary[];
+    agent_summaries?: AgentSummary[];
 }
 
 export function isNetworkSummary(obj: unknown): obj is NetworkSummary {
@@ -192,9 +192,9 @@ export function isNetworkSummary(obj: unknown): obj is NetworkSummary {
         typeof obj.name === 'string' &&
         'description' in obj &&
         typeof obj.description === 'string' &&
-        'agent_summaries' in obj &&
-        Array.isArray(obj.agent_summaries) &&
-        obj.agent_summaries.every(isAgentSummary)
+        ('agent_summaries' in obj
+            ? Array.isArray(obj.agent_summaries) && obj.agent_summaries.every(isAgentSummary)
+            : true)
     );
 }
 
@@ -492,16 +492,14 @@ function isDeviceCategoryEntry(obj: unknown): obj is DeviceCategoryEntry {
 }
 
 export interface DeviceCategories {
-    entries: DeviceCategoryEntry[];
+    entries?: DeviceCategoryEntry[];
 }
 
 function isDeviceCategories(obj: unknown): obj is DeviceCategories {
     return (
         typeof obj === 'object' &&
         obj !== null &&
-        'entries' in obj &&
-        Array.isArray(obj.entries) &&
-        obj.entries.every(isDeviceCategoryEntry)
+        ('entries' in obj ? Array.isArray(obj.entries) && obj.entries.every(isDeviceCategoryEntry) : true)
     );
 }
 
@@ -558,6 +556,7 @@ export class Device {
     device_categories: DeviceCategories;
     protocol_profile: ProtocolProfile;
     timestamp: string;
+    custom_name?: string;
 
     constructor(
         ip_address: string,
@@ -567,7 +566,8 @@ export class Device {
         device_class: DeviceClass,
         device_categories: DeviceCategories,
         protocol_profile: ProtocolProfile,
-        timestamp: string
+        timestamp: string,
+        custom_name?: string
     ) {
         this.ip_address = ip_address;
         this.mac_address = mac_address;
@@ -577,6 +577,7 @@ export class Device {
         this.device_categories = device_categories;
         this.protocol_profile = protocol_profile;
         this.timestamp = timestamp;
+        this.custom_name = custom_name;
     }
 }
 
@@ -598,6 +599,7 @@ export function isDevice(obj: unknown): obj is Device {
         'protocol_profile' in obj &&
         isProtocolProfile(obj.protocol_profile) &&
         'timestamp' in obj &&
-        typeof obj.timestamp === 'string'
+        typeof obj.timestamp === 'string' &&
+        ('custom_name' in obj ? typeof obj.custom_name === 'string' : true)
     );
 }

--- a/editorextensions/UVexplorer-integration/package-lock.json
+++ b/editorextensions/UVexplorer-integration/package-lock.json
@@ -21,6 +21,7 @@
                 "raw-loader": "^4.0.2",
                 "ts-jest": "^29.1.2",
                 "ts-loader": "^9.2.6",
+                "tsconfig-paths-webpack-plugin": "^4.1.0",
                 "typescript": "^5.3.3",
                 "webpack": "^5.64.4"
             }
@@ -6302,6 +6303,43 @@
                 "json5": "^1.0.2",
                 "minimist": "^1.2.6",
                 "strip-bom": "^3.0.0"
+            }
+        },
+        "node_modules/tsconfig-paths-webpack-plugin": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.1.0.tgz",
+            "integrity": "sha512-xWFISjviPydmtmgeUAuXp4N1fky+VCtfhOkDUFIv5ea7p4wuTomI4QTrXvFBX2S4jZsmyTSrStQl+E+4w+RzxA==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "enhanced-resolve": "^5.7.0",
+                "tsconfig-paths": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/tsconfig-paths-webpack-plugin/node_modules/strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+            "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+            "dev": true,
+            "dependencies": {
+                "json5": "^2.2.2",
+                "minimist": "^1.2.6",
+                "strip-bom": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/tsconfig-paths/node_modules/json5": {

--- a/editorextensions/UVexplorer-integration/package.json
+++ b/editorextensions/UVexplorer-integration/package.json
@@ -12,6 +12,7 @@
         "raw-loader": "^4.0.2",
         "ts-jest": "^29.1.2",
         "ts-loader": "^9.2.6",
+        "tsconfig-paths-webpack-plugin": "^4.1.0",
         "typescript": "^5.3.3",
         "webpack": "^5.64.4"
     },

--- a/editorextensions/UVexplorer-integration/src/extension.ts
+++ b/editorextensions/UVexplorer-integration/src/extension.ts
@@ -1,5 +1,5 @@
 import { EditorClient, Menu, Modal, Viewport } from 'lucid-extension-sdk';
-import { UVexplorerModal } from '@uvx/devices-modal';
+import { DevicesModal } from '@uvx/devices-modal';
 import { showConnectedDevices, uvDeviceSelected } from '@actions/devices';
 
 class FirstModal extends Modal {
@@ -42,7 +42,7 @@ menu.addContextMenuItem({
 });
 
 client.registerAction('loadNetwork', async () => {
-    const modal = new UVexplorerModal(client, viewport);
+    const modal = new DevicesModal(client, viewport);
 
     // Configuring settings using the showPackageSettingsModal() did not work locally
     // await modal.configureSetting('apiKey');

--- a/editorextensions/UVexplorer-integration/src/network-devices/network-device-blocks.ts
+++ b/editorextensions/UVexplorer-integration/src/network-devices/network-device-blocks.ts
@@ -65,9 +65,11 @@ export class NetworkDeviceBlocks {
 
     private getDeviceType(device: Device) {
         const deviceTypes = new Set<string>();
-        device.device_categories.entries.forEach((type) => {
-            deviceTypes.add(type.device_category);
-        });
+        if (device.device_categories.entries !== undefined) {
+            device.device_categories.entries.forEach((type) => {
+                deviceTypes.add(type.device_category);
+            });
+        }
 
         const deviceType = this.findCategory(deviceTypes);
         return deviceType;

--- a/editorextensions/UVexplorer-integration/src/uvx/devices-modal.ts
+++ b/editorextensions/UVexplorer-integration/src/uvx/devices-modal.ts
@@ -5,15 +5,16 @@ import { UVXModal } from './uvx-modal';
 import {
     addDevicesToCollection,
     createOrRetrieveDeviceCollection,
-    createOrRetrieveNetworkSource
+    createOrRetrieveNetworkSource,
+    deleteDevicesFromCollection,
+    updatePageMap
 } from '../data-collections';
 
-export class UVexplorerModal extends UVXModal {
+export class DevicesModal extends UVXModal {
     private viewport: Viewport;
 
     constructor(client: EditorClient, viewport: Viewport) {
         super(client);
-
         this.viewport = viewport;
     }
 
@@ -36,6 +37,10 @@ export class UVexplorerModal extends UVXModal {
             const networkRequest = new NetworkRequest(guid);
             await this.uvexplorerClient.loadNetwork(this.serverUrl, this.sessionGuid, networkRequest);
             const source = createOrRetrieveNetworkSource(name, guid);
+            const page = this.viewport.getCurrentPage();
+            if (page !== undefined) {
+                updatePageMap(page.id, guid);
+            }
             console.log(`Successfully loaded network: ${name}`);
             return source;
         } catch (e) {
@@ -53,6 +58,7 @@ export class UVexplorerModal extends UVXModal {
                 this.sessionGuid,
                 deviceListRequest
             );
+            deleteDevicesFromCollection(collection); // TODO: Replace once updateDevicesInCollection Function is implemented
             addDevicesToCollection(collection, devices);
             await this.sendMessage({
                 action: 'listDevices',

--- a/editorextensions/UVexplorer-integration/webpack.config.js
+++ b/editorextensions/UVexplorer-integration/webpack.config.js
@@ -17,9 +17,7 @@ module.exports = {
         ]
     },
     resolve: {
-        plugins: [
-            new TsconfigPathsPlugin()
-        ],
+        plugins: [new TsconfigPathsPlugin()],
         extensions: ['.ts', '.js']
     },
     output: {

--- a/editorextensions/UVexplorer-integration/webpack.config.js
+++ b/editorextensions/UVexplorer-integration/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
 
 module.exports = {
     entry: './src/extension.ts',
@@ -17,6 +18,11 @@ module.exports = {
         ]
     },
     resolve: {
+        plugins: [
+            new TsconfigPathsPlugin({
+                /* options: see below */
+            })
+        ],
         extensions: ['.ts', '.js']
     },
     output: {

--- a/editorextensions/UVexplorer-integration/webpack.config.js
+++ b/editorextensions/UVexplorer-integration/webpack.config.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
 
 module.exports = {
@@ -19,9 +18,7 @@ module.exports = {
     },
     resolve: {
         plugins: [
-            new TsconfigPathsPlugin({
-                /* options: see below */
-            })
+            new TsconfigPathsPlugin()
         ],
         extensions: ['.ts', '.js']
     },


### PR DESCRIPTION
udates webpack config with path aliasing plugin so the extension can be tested in the browser

updates data model so both of our network's devices are parsed properly

adds PageMap data source/collection to keep track of which network is loaded on the current page at any given time.

getNetworkForPage(pageId: string): string - returns the networkGuid associated with a given page.Id

devices are now cleared from their collection before being re-added so there are not duplicates. 